### PR TITLE
Update handlebars.js

### DIFF
--- a/tasks/extractors/handlebars.js
+++ b/tasks/extractors/handlebars.js
@@ -113,7 +113,7 @@ module.exports = function(file, options) {
         fn = _.flatten([ options.functionName ]);
 
     _.each(fn, function(func) {
-        var regex = new RegExp("\\{\\{\\s*" + func + "\\s+(.*?)\\}\\}", "g");
+        var regex = new RegExp("(?:\\{\\{|\\()\\s*" + func + "\\s+(.*?)\\s*(?:\\}\\}|\\))", "g");
         var result;
         while ((result = regex.exec(contents)) !== null) {
             var tokens = tokenize(result[1]);


### PR DESCRIPTION
New regexp so it also handles subexpressions in handlebars. It will now match both {{ tr "my text" }} and {{> "component" text=(tr "my text") }}.
